### PR TITLE
Allow individual commands to have state "absent"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
     - sudoers_group
     - sudoers_host
   when:
-    ( item.state is not defined 
+    ( item.state is not defined
       or item.state != "absent")
     and item.cmd_name is defined
     and item.cmd_list is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,30 +2,33 @@
 # tasks file for sudoers
 
 - name: create sudoers-file in /etc/sudoers.d per entry in array
+  tags: sudo
   template:
     src: "sudoers.j2"
     dest: "{{ sudoers_dir_path }}{{ item.cmd_name }}"
     owner: "root"
     group: "root"
-    mode: "0640"
+    mode: "0440"
     validate: visudo -cf %s
   with_flattened:
     - sudoers_all
     - sudoers_group
     - sudoers_host
   when:
-    file_state == "present"
-    or file_state == "latest"
+    ( item.state is not defined 
+      or item.state != "absent")
     and item.cmd_name is defined
     and item.cmd_list is defined
     and item.cmd_users is defined
 - name: remove sudoers-file when state absent
+  tags: sudo
   file:
     dest: "{{ sudoers_dir_path }}{{ item.cmd_name }}"
-    state: "{{ file_state }}"
+    state: "{{ item.state }}"
   with_flattened:
     - sudoers_all
     - sudoers_group
     - sudoers_host
   when:
-    file_state == "absent"
+    item.state is defined
+    and item.state == "absent"


### PR DESCRIPTION
Modified tasks/main.yml to item.state rather than file_state

This allows a sudoers command to have state "absent".

```
sudoers_group:
    - cmd_name: APT
      cmd_list:
          - "/usr/bin/apt-get"
      cmd_users:
          - "fredflintstone"
      state: absent
```

If state is not defined or is set to any value other than "absent" then the sudoers file will be created.

If state is absent it will be deleted.
